### PR TITLE
Make gbagfx JASC palette reading CRLF/CR/LF agnostic

### DIFF
--- a/tools/gbagfx/jasc_pal.c
+++ b/tools/gbagfx/jasc_pal.c
@@ -22,45 +22,55 @@
 // Blue  - "0 0 255\r\n"
 // Brown - "150 75 0\r\n"
 
-#define MAX_LINE_LENGTH 11
 
 void ReadJascPaletteLine(FILE *fp, char *line)
 {
     int c;
     int length = 0;
+    int numSpaces = 0; 
 
     for (;;)
     {
         c = fgetc(fp);
 
-        if (c == '\r')
-        {
+        // CRLF or CR
+        if (c == '\r') {
             c = fgetc(fp);
-
-            if (c != '\n')
-                FATAL_ERROR("CR line endings aren't supported.\n");
+            if (c != '\n') {
+                // put it back!
+                ungetc(c, fp);
+            }
 
             line[length] = 0;
-
             return;
         }
 
-        if (c == '\n')
-            FATAL_ERROR("LF line endings aren't supported.\n");
-
-        if (c == EOF)
-            FATAL_ERROR("Unexpected EOF. No CRLF at end of file.\n");
-
-        if (c == 0)
-            FATAL_ERROR("NUL character in file.\n");
-
-        if (length == MAX_LINE_LENGTH)
-        {
+        // LF only
+        if (c == '\n'){
             line[length] = 0;
-            FATAL_ERROR("The line \"%s\" is too long.\n", line);
+            return;
         }
 
-        line[length++] = c;
+        if (c == 0)
+            FATAL_ERROR("NULL character in file.\n");
+
+        if (c == 0)
+            FATAL_ERROR("Unexpected EOF. No CRLF, CR, or LF at end of file.\n");
+            
+        // Count the number of spaces encountered
+        // Should be 2 then a newline. If 3, then
+        // there's an alpha afterward. Keep reading
+        // to consume chars, but don't save them
+        if (c == ' ') 
+            numSpaces++;
+
+        if (numSpaces < 3) {
+            line[length] = c;
+        } else if (numSpaces == 3) {
+            line[length] = 0;
+        }
+
+        length++;
     }
 }
 


### PR DESCRIPTION
When I tried exporting a .pal file from Aseprite, it produced a version 0100 palette like this utility specifies, but it used `\n` instead of `\t\n`, and included the alpha channel in addition to the colour channels. Aseprite is a common pixel art tool, so I though it would be helpful if gbagfx could handle parsing these palettes as well.

I have very little experience with C, but I have tested this modification with both stock .pal files from the pkmnfirered repo and Aseprite .pal exports to confirm it handles both. Still, I'm not sure I haven't done something terrible, so it would be worth reviewing if anyone feels like it.

[An example of a 16 colour Aseprite JASC .pal export](https://github.com/waterwheels/pokefirered/files/11344355/Aseprite-Type-JASC.pal.zip)
